### PR TITLE
Add `inclusive` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,11 @@ export type Range = {
 	Whether or not to include the end value in the range.
 
 	@default false
+	@example
+	```
+	console.log(...getRange({start: 3, end: 5, inclusive: true}));
+	//=> [3, 4, 5]
+	```
 	*/
 	readonly inclusive?: boolean;
 };
@@ -51,8 +56,8 @@ range.next().value;
 range.next().value;
 //=> 2
 
-console.log(...getRange({start: 0, end: -5, step: -1, inclusive: true}));
-//=> [0, -1, -2, -3, -4, -5]
+console.log(...getRange({start: 0, end: -5, step: -1}));
+//=> [0, -1, -2, -3, -4]
 ```
 */
 export default function getRange(range: Range): IterableIterator<number>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,13 @@ export interface Range {
 	@default 1
 	*/
 	readonly step?: number;
+
+	/**
+	Whether or not to include the end value in the range.
+
+	@default false
+	*/
+	readonly inclusive?: boolean;
 }
 
 /**
@@ -44,8 +51,8 @@ range.next().value;
 range.next().value;
 //=> 2
 
-console.log(...getRange({start: 0, end: -5, step: -1}));
-//=> [0, -1, -2, -3, -4]
+console.log(...getRange({start: 0, end: -5, step: -1, inclusive: true}));
+//=> [0, -1, -2, -3, -4, -5]
 ```
 */
 export default function getRange(range: Range): IterableIterator<number>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,8 +24,11 @@ export type Range = {
 	Whether or not to include the end value in the range.
 
 	@default false
+
 	@example
 	```
+ 	import getRange from 'get-range';
+
 	console.log(...getRange({start: 3, end: 5, inclusive: true}));
 	//=> [3, 4, 5]
 	```

--- a/index.js
+++ b/index.js
@@ -6,8 +6,10 @@ const validate = (name, value) => {
 
 const lt = (l, r) => l < r;
 const gt = (l, r) => l > r;
+const lte = (l, r) => l <= r;
+const gte = (l, r) => l >= r;
 
-export default function * getRange({start = 0, end, step = 1}) {
+export default function * getRange({start = 0, end, step = 1, inclusive = false}) {
 	if (step === 0) {
 		throw new TypeError('The `step` parameter cannot be zero');
 	}
@@ -16,7 +18,9 @@ export default function * getRange({start = 0, end, step = 1}) {
 	validate('end', end);
 	validate('step', step);
 
-	const compare = step < 0 ? gt : lt;
+	const compareExclusive = step < 0 ? gt : lt;
+	const compareInclusive = step < 0 ? gte : lte;
+	const compare = inclusive ? compareInclusive : compareExclusive;
 
 	for (let index = start; compare(index, end); index += step) {
 		yield index;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,6 +4,7 @@ import getRange from './index.js';
 expectType<IterableIterator<number>>(getRange({end: -5}));
 expectType<IterableIterator<number>>(getRange({start: 0, end: -5}));
 expectType<IterableIterator<number>>(getRange({start: 0, end: -5, step: -1}));
+expectType<IterableIterator<number>>(getRange({start: 0, end: -5, step: -1, inclusive: true}));
 
 for (const index of getRange({end: 4})) {
 	console.log(index);

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,8 @@ range.next().value;
 range.next().value;
 //=> 2
 
-console.log(...getRange({start: 0, end: -5, step: -1, inclusive: true}));
-//=> [0, -1, -2, -3, -4, -5]
+console.log(...getRange({start: 0, end: -5, step: -1}));
+//=> [0, -1, -2, -3, -4]
 ```
 
 It can replace normal for-loops in many cases:
@@ -84,3 +84,8 @@ Type: `boolean`\
 Default: `false`
 
 Whether or not to include the end value in the range.
+
+```js
+console.log(...getRange({start: 3, end: 5, inclusive: true}));
+//=> [3, 4, 5]
+```

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,8 @@ Default: `false`
 Whether or not to include the end value in the range.
 
 ```js
+import getRange from 'get-range';
+
 console.log(...getRange({start: 3, end: 5, inclusive: true}));
 //=> [3, 4, 5]
 ```

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,8 @@ range.next().value;
 range.next().value;
 //=> 2
 
-console.log(...getRange({start: 0, end: -5, step: -1}));
-//=> [0, -1, -2, -3, -4]
+console.log(...getRange({start: 0, end: -5, step: -1, inclusive: true}));
+//=> [0, -1, -2, -3, -4, -5]
 ```
 
 It can replace normal for-loops in many cases:
@@ -77,3 +77,10 @@ Default: `1`\
 Minimum: `1`
 
 Distance between numbers.
+
+##### inclusive
+
+Type: `boolean`\
+Default: `false`
+
+Whether or not to include the end value in the range.

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import getRange from './index.js';
 
+/** @param {import('.').Range} range */
 const get = range => [...getRange(range)];
 
 test('main', t => {
@@ -31,6 +32,14 @@ test('main', t => {
 	t.deepEqual(get({start: 0, end: -3, step: -2}), [0, -2]);
 	t.deepEqual(get({start: 0, end: -4, step: -2}), [0, -2]);
 	t.deepEqual(get({start: 0, end: -6, step: -2}), [0, -2, -4]);
+
+	t.deepEqual(get({end: 0, inclusive: true}), [0]);
+	t.deepEqual(get({end: 1, inclusive: true}), [0, 1]);
+	t.deepEqual(get({end: -2, inclusive: true}), []);
+	t.deepEqual(get({start: 1, end: 5, inclusive: true}), [1, 2, 3, 4, 5]);
+	t.deepEqual(get({start: 0, end: 2, step: 2, inclusive: true}), [0, 2]);
+	t.deepEqual(get({start: 0, end: 3, step: 2, inclusive: true}), [0, 2]);
+	t.deepEqual(get({start: 0, end: -6, step: -2, inclusive: true}), [0, -2, -4, -6]);
 });
 
 test('generator', t => {


### PR DESCRIPTION
Resolves #4.

Adds an `inclusive` option for inclusive ranges:

```js
for (const index of getRange({end: 4, inclusive: true})) {
	console.log(index);
}

//=> 0
//=> 1
//=> 2
//=> 3
//=> 4
```