### PR TITLE
Target Node.js 18, update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
           - 20
           - 18
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
           - 20
           - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
-          - 14
-          - 12
+          - 20
+          - 18
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export interface Range {
+export type Range = {
 	/**
 	Start of the range.
 
@@ -19,7 +19,7 @@ export interface Range {
 	@default 1
 	*/
 	readonly step?: number;
-}
+};
 
 /**
 Lazy number range generator.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -36,8 +36,8 @@
 		"numbers"
 	],
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.39.1"
+		"ava": "^6.0.1",
+		"tsd": "^0.30.1",
+		"xo": "^0.56.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,8 @@ Similar to the Python 3 [`range`](https://docs.python.org/3/library/stdtypes.htm
 
 ## Install
 
-```
-$ npm install get-range
+```sh
+npm install get-range
 ```
 
 ## Usage


### PR DESCRIPTION
This PR:

- targets Node.js 18
- updates dependencies
- updates the test version matrix and uses `actions` v3
- includes misc style updates from updating `xo`
- removes an extraneous `$` from the install command in the readme